### PR TITLE
fix: files cannot be created

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"github.com/KarlGW/secman/internal/filesystem"
 	"github.com/KarlGW/secman/internal/security"
 	"github.com/zalando/go-keyring"
 	"gopkg.in/yaml.v3"
@@ -51,12 +52,12 @@ func Configure(options ...Option) (cfg Configuration, err error) {
 		option(&cfg)
 	}
 
-	configFile, err := os.OpenFile(filepath.Join(cfg.path, configFile), os.O_CREATE|os.O_RDWR, 0600)
+	configFile, err := filesystem.OpenFile(filepath.Join(cfg.path, configFile), os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return
 	}
 
-	profilesFile, err := os.OpenFile(filepath.Join(cfg.path, profilesFile), os.O_CREATE|os.O_RDWR, 0600)
+	profilesFile, err := filesystem.OpenFile(filepath.Join(cfg.path, profilesFile), os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return
 	}
@@ -115,7 +116,7 @@ func (c *Configuration) Load(file *os.File) error {
 
 // Save the Configuration to file.
 func (c Configuration) Save() (err error) {
-	file, err := os.OpenFile(filepath.Join(c.path, configFile), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
+	file, err := filesystem.OpenFile(filepath.Join(c.path, configFile), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/config/profiles.go
+++ b/config/profiles.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/KarlGW/secman/internal/filesystem"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
@@ -50,7 +51,7 @@ func (p *profiles) Load(file *os.File) error {
 
 // Save the profiles to file.
 func (p profiles) Save() (err error) {
-	file, err := os.OpenFile(filepath.Join(p.path, profilesFile), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
+	file, err := filesystem.OpenFile(filepath.Join(p.path, profilesFile), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 )
 
-// OpenFile wraps around the standard library fs.OpenFile with addition
-// of creating the path to the file if it doesn't exist.
+// OpenFile wraps around the standard library os.OpenFile with addition
+// of creating the path to the file if it doesn't exist with os.MkdirAll.
 func OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
 	if err := os.MkdirAll(filepath.Dir(name), 0700); err != nil {
 		return nil, err

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -1,0 +1,16 @@
+package filesystem
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// OpenFile wraps around the standard library fs.OpenFile with addition
+// of creating the path to the file if it doesn't exist.
+func OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(name), 0700); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(name, flag, perm)
+}

--- a/secret/collection_test.go
+++ b/secret/collection_test.go
@@ -41,6 +41,9 @@ func TestCollection_Encode_Decode(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			encoded, gotErr := gob.Encode(test.input)
+			if gotErr != nil {
+				t.Errorf("unexpected error in test, could not encode to gob")
+			}
 			got := Collection{}
 			gotErr = gob.Decode(encoded, &got)
 

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"os"
 	"time"
+
+	"github.com/KarlGW/secman/internal/filesystem"
 )
 
 var (
@@ -35,7 +37,7 @@ func NewFileSystem(path string, options ...FileSystemOption) FileSystem {
 
 // Save data to the file.
 func (f FileSystem) Save(data []byte) (err error) {
-	file, err := os.OpenFile(f.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	file, err := filesystem.OpenFile(f.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrStorageSourceNotFound, err)
 	}

--- a/storage/filesystem_test.go
+++ b/storage/filesystem_test.go
@@ -82,8 +82,8 @@ func TestFileSystem_Save(t *testing.T) {
 				path: filepath.Join("../", _testRoot, _testDir, _testFile),
 				data: []byte(`test`),
 			},
-			want:    nil,
-			wantErr: ErrStorageSourceNotFound,
+			want:    []byte(`test`),
+			wantErr: nil,
 		},
 	}
 


### PR DESCRIPTION
The collection file could not be saved properly when it did not exist. This pull request adjusts that with adding an internal package, `filesystem` which wraps around `os.OpenFile` with the  addition of calling `os.MkdirAll` with it's path before.